### PR TITLE
Add handling for multiple job names for different ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ If your container exposes metrics on more than one port for a single task you ca
 * `PROMETHEUS_EXPORTER_PORT.1` `9180` - Set the first port exposing metrics 
 * `PROMETHEUS_EXPORTER_PORT.2` `8080` - Set the second port exposing metrics
 * `PROMETHEUS_EXPORTER_PATH.2` `/api/v1/metrics` - The second port exposes metrics on a non-standard path of `/api/v1/metrics` 
+* `PROMETHEUS_EXPORTER_JOB_NAME.2` `logging` - The second port has a separate job name, `logging`, useful for differentiating otherwise identical metrics

--- a/main.go
+++ b/main.go
@@ -293,6 +293,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			}
 			var exporterServerName string
 			var exporterPath string
+			var exporterJobName string
 			var ok bool
 			exporterServerName, ok = d.DockerLabels[*prometheusServerNameLabel]
 			if ok {
@@ -318,6 +319,11 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 				exporterPath, ok = d.DockerLabels[*prometheusPathLabel+key]
 				if ok {
 					labels.MetricsPath = exporterPath
+				}
+
+				exporterJobName, ok = d.DockerLabels[*prometheusJobNameLabel+key]
+				if ok {
+					labels.JobName = exporterJobName
 				}
 
 				ret = append(ret, &PrometheusTaskInfo{


### PR DESCRIPTION
Allows tasks with multiple exposed ports to have a separate job name for those ports and path pairs.

This will be used for our implementation where we have both Caddy and Application metrics coming out from the same container on separate ports, and we have no way to differentiate the `up` metric that is collected, rather than all jobs being tagged with `ecs` or the same otherwise defined job name.